### PR TITLE
add note that this is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Author: ChrisDeadman
 
 Convert a USB HID device (joystick, gamepad) into a Gameport joystick with the power of arduino :-)
 
+**Note**: This is obsolete and has been superseded by [usb-to-ps2-gameport-hat](https://github.com/ChrisDeadman/usb-to-ps2-gameport-hat).
+
 ![Example Device](example_device.jpg)
 
 ## Notes


### PR DESCRIPTION
I saw you forked this repo - just wanted to inform you that it's better if you use [usb-to-ps2-gameport-hat](https://github.com/ChrisDeadman/usb-to-ps2-gameport-hat) since that one is the newer version, has support for more devices and inludes schematic (you don't have to use the PS/2 part if you don't need it)